### PR TITLE
Fix insert put data reference modification

### DIFF
--- a/deta/base.py
+++ b/deta/base.py
@@ -117,6 +117,8 @@ class Base:
     def insert(self, data: typing.Union[dict, list, str, int, bool], key: str = None):
         if not isinstance(data, dict):
             data = {"value": data}
+        else:
+            data = data.copy()
 
         if key:
             data["key"] = key
@@ -135,6 +137,8 @@ class Base:
 
         if not isinstance(data, dict):
             data = {"value": data}
+        else:
+            data = data.copy()
 
         if key:
             data["key"] = key

--- a/tests.py
+++ b/tests.py
@@ -44,9 +44,11 @@ class TestBaseMethods(unittest.TestCase):
         self.db.client.close()
 
     def test_put(self):
+        item = {"msg": "hello"}
         resp = {"key": "one", "msg": "hello"}
-        self.assertEqual(self.db.put({"msg": "hello"}, "one"), resp)
-        self.assertEqual(self.db.put({"key": "one", "msg": "hello"}), resp)
+        self.assertEqual(self.db.put(item, "one"), resp)
+        self.assertEqual(self.db.put(item, "one"), resp)
+        self.assertEqual({"msg": "hello"}, item)
         self.assertEqual(set(self.db.put("Hello").keys()), set(["key", "value"]))
         self.assertEqual(set(self.db.put(1).keys()), set(["key", "value"]))
         self.assertEqual(set(self.db.put(True).keys()), set(["key", "value"]))
@@ -72,9 +74,11 @@ class TestBaseMethods(unittest.TestCase):
         self.db.put_many([i for i in range(26)])
 
     def test_insert(self):
+        item = {"msg": "hello"}
         self.assertEqual(
-            set(self.db.insert({"msg": "hello"}).keys()), set(["key", "msg"])
+            set(self.db.insert(item).keys()), set(["key", "msg"])
         )
+        self.assertEqual({"msg": "hello"}, item)
 
     @unittest.expectedFailure
     def test_insert_fail(self):


### PR DESCRIPTION
In Base the insert/put methods:
```
def insert(self, data: typing.Union[dict, list, str, int, bool], key: str = None):
def put(self, data: typing.Union[dict, list, str, int, bool], key: str = None):
```
are modifying the data argument, if data is a dict, then the reference to data is modifying the user object.
```
if key:
    data["key"] = key
```
to avoid that a simple shallow copy of data should do the trick, as in here:
```
if not isinstance(data, dict):
    data = {"value": data}
else:
    data = data.copy()
```
Tests have also been added to assert the modifications.