### PR TITLE
update base service timeout to 300 seconds, fixes #53

### DIFF
--- a/deta/base.py
+++ b/deta/base.py
@@ -1,10 +1,11 @@
 import os
-import json
 import typing
 from urllib.parse import quote
 
 from .service import _Service, JSON_MIME
 
+# timeout for Base service in seconds
+BASE_SERVICE_TIMEOUT = 300 
 
 class FetchResponse:
     def __init__(self, count=0, last=None, items=[]):
@@ -77,7 +78,7 @@ class _Base(_Service):
             project_id=project_id,
             host=host,
             name=name,
-            timeout=3,
+            timeout=BASE_SERVICE_TIMEOUT,
         )
         self.util = Util()
 

--- a/deta/drive.py
+++ b/deta/drive.py
@@ -1,14 +1,15 @@
 import os
 import typing
-import http
 from io import BufferedIOBase, TextIOBase, RawIOBase, StringIO, BytesIO
 from urllib.parse import quote_plus
-import http.client
 
 from .service import JSON_MIME, _Service
 
 # 10 MB upload chunk size
 UPLOAD_CHUNK_SIZE = 1024 * 1024 * 10
+
+# timeout for Drive service in seconds
+DRIVE_SERVICE_TIMEOUT = 300
 
 
 class DriveStreamingBody:
@@ -60,7 +61,7 @@ class _Drive(_Service):
             project_id=project_id,
             host=host,
             name=name,
-            timeout=300,
+            timeout=DRIVE_SERVICE_TIMEOUT,
             keep_alive=False,
         )
 


### PR DESCRIPTION
- update base service client timeout as it was too low previously (only 3 seconds), the client would time out if base service was slower