### PR TITLE
README.md: Fix the broken link to the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Deta Python Library (SDK)
 
-Supports Python 3.5+ only. [Read the docs.](https://deta.space/docs/en/reference/base/sdk)  
+Please use a [supported version of Python](https://devguide.python.org/versions/).  [Read the docs.](https://deta.space/docs)  
 
 Install from PyPi
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Deta Python Library (SDK)
 
-Please use a [supported version of Python](https://devguide.python.org/versions/).  [Read the docs.](https://deta.space/docs)  
+Please use a [supported version of Python](https://devguide.python.org/versions/).  This package requires a minimum of Python 3.6.  [Read the docs.](https://deta.space/docs/en/build/reference/sdk)  
 
 Install from PyPi
 


### PR DESCRIPTION
https://deta.space/docs/en/reference/base/sdk currently goes nowhere. 